### PR TITLE
Update links to actually link to a pdf

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,38 +90,51 @@
                 <div class="post-preview">
                     <a href="post.html">
                         <h2 class="post-title">
-                            Issue 1
+                            The Science of Hurricanes
                         </h2>
                         <h3 class="post-subtitle">
-                            Oct 2016
+                            Oct 2017
                         </h3>
                     </a>
-                    <button type="submit" onclick="window.open('img/post-sample-image.jpg')">Download</button>
+                    <button type="submit" onclick="window.open('img/2017 Issue 1.pdf')">Download</button>
                 </div>
                 <hr>
                 <div class="post-preview">
                     <a href="post.html">
                         <h2 class="post-title">
-                            Issue 2
+                            It's that Smart Phone, isn't It?
                         </h2>
                         <h3 class="post-subtitle">
-                            Nov 2016
+                            March 2017
                         </h3>
                     </a>
-                <button type="submit" onclick="window.open('img/post-sample-image.jpg')">Download</button>
+                <button type="submit" onclick="window.open('img/2017 Issue 1.pd')">Download</button>
            
                 </div>
                 <hr>
                 <div class="post-preview">
                     <a href="post.html">
                         <h2 class="post-title">
-                            Issue 3
+                            The Mind Bending Science behind Dr.Strange
                         </h2>
                         <h3 class="post-subtitle">
-                            March 2017
+                            Nov 2016
                         </h3>
                     </a>
-                    <button type="submit" onclick="window.open('img/post-sample-image.jpg')">Download</button>
+                <button type="submit" onclick="window.open('img/2017 Issue 1.pd')">Download</button>
+           
+                </div>
+                <hr>
+                <div class="post-preview">
+                    <a href="post.html">
+                        <h2 class="post-title">
+                            Global Warming Unmasked
+                        </h2>
+                        <h3 class="post-subtitle">
+                            Oct 2016
+                        </h3>
+                    </a>
+                    <button type="submit" onclick="window.open('img/2017 Issue 1.pd')">Download</button>
                     
                 </div>
                 <hr>


### PR DESCRIPTION
The file name of the 2017 issue includes spaces so it might be considered invalid. If so, you're going to have to replace those spaces with underscores.